### PR TITLE
Update GPTQ with latest upstream changes

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2667,7 +2667,7 @@ def prepare_4bit_load(modelpath):
     groupsize = -1
     for p in paths_4bit:
         p = os.path.join(modelpath, p)
-        val = glob.glob(p)
+        val = [v for v in glob.glob(p) if "4bit-old" not in v]
         if val:
             result = val[0]
             fname = Path(result).parts[-1]

--- a/aiserver.py
+++ b/aiserver.py
@@ -94,6 +94,7 @@ sys.path.insert(0, os.path.abspath(Path("repos/gptq")))
 from gptj import load_quant as gptj_load_quant
 from gptneox import load_quant as gptneox_load_quant
 from llama import load_quant as llama_load_quant
+from opt import load_quant as opt_load_quant
 monkey_patched_4bit = False
 
 
@@ -3169,6 +3170,9 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                             elif koboldai_vars.model_type == "llama":
                                 model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4, -1)
                                 tokenizer = LlamaTokenizer.from_pretrained(koboldai_vars.custmodpth)
+                            elif koboldai_vars.model_type == "opt":
+                                model = opt_load_quant(koboldai_vars.custmodpth, path_4bit, 4)
+                                tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             else:
                                 raise RuntimeError(f"4-bit load failed. Model type {koboldai_vars.model_type} not supported in 4-bit")
 

--- a/aiserver.py
+++ b/aiserver.py
@@ -3172,7 +3172,7 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                             else:
                                 raise RuntimeError(f"4-bit load failed. Model type {koboldai_vars.model_type} not supported in 4-bit")
 
-                            model = model.float()
+                            model = model.half()
                         else:
                             try:
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth, revision=koboldai_vars.revision, cache_dir="cache", use_fast=False)

--- a/aiserver.py
+++ b/aiserver.py
@@ -3144,6 +3144,7 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
 
                 if offload_4bit:
                     koboldai_vars.lazy_load = False
+                    print("4-bit CPU offloader active")
                 
                 # If we're using torch_lazy_loader, we need to get breakmodel config
                 # early so that it knows where to load the individual model tensors
@@ -3176,10 +3177,16 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
 
                             print(f"Trying to load {koboldai_vars.model_type} model in 4-bit")
                             if koboldai_vars.model_type == "gptj":
-                                model = gptj_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
+                                if offload_4bit:
+                                    model = load_quant_offload(gptj_load_quant, koboldai_vars.custmodpth, path_4bit, 4, groupsize, gpu_layers_list)
+                                else:
+                                    model = gptj_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "gpt_neox":
-                                model = gptneox_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
+                                if offload_4bit:
+                                    model = load_quant_offload(gptneox_load_quant, koboldai_vars.custmodpth, path_4bit, 4, groupsize, gpu_layers_list)
+                                else:
+                                    model = gptneox_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "llama":
                                 if offload_4bit:
@@ -3188,7 +3195,10 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                                     model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = LlamaTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "opt":
-                                model = opt_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
+                                if offload_4bit:
+                                    model = load_quant_offload(opt_load_quant, koboldai_vars.custmodpth, path_4bit, 4, groupsize, gpu_layers_list)
+                                else:
+                                    model = opt_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             else:
                                 raise RuntimeError(f"4-bit load failed. Model type {koboldai_vars.model_type} not supported in 4-bit")

--- a/aiserver.py
+++ b/aiserver.py
@@ -3136,13 +3136,13 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                             koboldai_vars.breakmodel = False
                             koboldai_vars.usegpu = True
                             if koboldai_vars.model_type == "gptj":
-                                model = gptj_load_quant(koboldai_vars.custmodpth, path_4bit, 4)
+                                model = gptj_load_quant(koboldai_vars.custmodpth, path_4bit, 4, -1)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "gpt_neox":
-                                model = gptneox_load_quant(koboldai_vars.custmodpth, path_4bit, 4)
+                                model = gptneox_load_quant(koboldai_vars.custmodpth, path_4bit, 4, -1)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "llama":
-                                model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4)
+                                model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4, -1)
                                 tokenizer = LlamaTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             else:
                                 raise RuntimeError(f"4-bit load failed. Model type {koboldai_vars.model_type} not supported in 4-bit")

--- a/aiserver.py
+++ b/aiserver.py
@@ -96,6 +96,7 @@ from gptj import load_quant as gptj_load_quant
 from gptneox import load_quant as gptneox_load_quant
 from llama import load_quant as llama_load_quant
 from opt import load_quant as opt_load_quant
+from offload import load_quant_offload
 monkey_patched_4bit = False
 
 
@@ -3137,6 +3138,12 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                 if(koboldai_vars.model_type == "gpt2"):
                     lowmem = {}
                     koboldai_vars.lazy_load = False  # Also, lazy loader doesn't support GPT-2 models
+
+                gpu_layers_list = [int(l) for l in gpu_layers.split(",")]
+                offload_4bit = use_4_bit and sum(gpu_layers_list) < utils.num_layers(model_config)
+
+                if offload_4bit:
+                    koboldai_vars.lazy_load = False
                 
                 # If we're using torch_lazy_loader, we need to get breakmodel config
                 # early so that it knows where to load the individual model tensors
@@ -3175,7 +3182,10 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                                 model = gptneox_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = AutoTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "llama":
-                                model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
+                                if offload_4bit:
+                                    model = load_quant_offload(llama_load_quant, koboldai_vars.custmodpth, path_4bit, 4, groupsize, gpu_layers_list)
+                                else:
+                                    model = llama_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
                                 tokenizer = LlamaTokenizer.from_pretrained(koboldai_vars.custmodpth)
                             elif koboldai_vars.model_type == "opt":
                                 model = opt_load_quant(koboldai_vars.custmodpth, path_4bit, 4, groupsize)
@@ -3286,7 +3296,10 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
                 patch_causallm(model)
 
                 if(koboldai_vars.hascuda):
-                    if(koboldai_vars.usegpu):
+                    if offload_4bit:
+                        koboldai_vars.modeldim = get_hidden_size_from_model(model)
+                        generator = model.generate
+                    elif(koboldai_vars.usegpu):
                         koboldai_vars.modeldim = get_hidden_size_from_model(model)
                         if not use_4_bit:
                             model = model.half().to(koboldai_vars.gpu_device)

--- a/aiserver.py
+++ b/aiserver.py
@@ -2659,7 +2659,7 @@ def prepare_4bit_load(modelpath):
         if val:
             result = val[0]
             fname = Path(result).parts[-1]
-            g = re.findall("^(?:4bit)(?:-)(\d+)(?:b-?)", fname)
+            g = re.findall("^(?:4bit)(?:-)(\d+)(?:g-?)", fname)
             if g:
                 groupsize = int(g[0])
             break

--- a/aiserver.py
+++ b/aiserver.py
@@ -2680,7 +2680,7 @@ def prepare_4bit_load(modelpath):
 
     # Monkey-patch in old-format pt-file support
     if not result:
-        print(f"4-bit file {path_4bit} not found, falling back to {path_4bit_old}")
+        print("4-bit file not found, falling back to old format.")
         for p in paths_4bit_old:
             p = os.path.join(modelpath, p)
             if os.path.isfile(p):
@@ -2688,8 +2688,8 @@ def prepare_4bit_load(modelpath):
                 break
 
         if not result:
-            print(f"4-bit old-format file {path_4bit} not found, loading failed")
-            raise RuntimeError(f"4-bit load failed. PT-File not found at {path_4bit}")
+            print("4-bit old-format file not found, loading failed.")
+            raise RuntimeError(f"4-bit load failed. PT-File not found.")
 
         import llama, opt, gptneox, gptj, old_quant
         llama.make_quant = old_quant.old_make_quant

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -11,6 +11,9 @@ dependencies:
   - pytorch=1.11.*
   - python=3.8.*
   - cudatoolkit=11.1
+  - cudatoolkit-dev=11.1
+  - gcc=9.*
+  - gxx=9.*
   - eventlet=0.33.3
   - dnspython=2.2.1
   - markdown
@@ -30,7 +33,7 @@ dependencies:
     - flask-ngrok
     - flask-cors
     - lupa==1.10
-    - git+https://github.com/huggingface/transformers@88dae78f4d204428568f749e864ef5ba09da7d24
+    - git+https://github.com/huggingface/transformers@c612628045822f909020f7eb6784c79700813eda
     - git+https://github.com/huggingface/datasets@test-pandas-2.0.0rc
     - huggingface_hub==0.12.1
     - safetensors

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -11,9 +11,6 @@ dependencies:
   - pytorch=1.11.*
   - python=3.8.*
   - cudatoolkit=11.1
-  - cudatoolkit-dev=11.1
-  - gcc=9.*
-  - gxx=9.*
   - eventlet=0.33.3
   - dnspython=2.2.1
   - markdown

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -29,7 +29,7 @@ dependencies:
     - flask-ngrok
     - flask-cors
     - lupa==1.10
-    - git+https://github.com/huggingface/transformers@88dae78f4d204428568f749e864ef5ba09da7d24
+    - git+https://github.com/huggingface/transformers@c612628045822f909020f7eb6784c79700813eda
     - huggingface_hub==0.12.1
     - safetensors
     - accelerate

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3173,14 +3173,7 @@ function save_preset() {
 function set_4_bit_mode(invert=true) {
 	bit_4_status = document.getElementById("use_4_bit").checked;
 	if (invert) {
-	bit_4_status = !bit_4_status;
-	}
-	if (bit_4_status) {
-		document.getElementById("modellayers").classList.add("hidden");
-		socket.emit("use_4_bit_toggle", {"use_4_bit": false});
-	} else {
-		document.getElementById("modellayers").classList.remove("hidden");
-		socket.emit("use_4_bit_toggle", {"use_4_bit": true});
+		bit_4_status = !bit_4_status;
 	}
 }
 


### PR DESCRIPTION
There's a number of big changes:
* Updated GPTQ needs new quantizations, incompatible with old format.
* This decreases the initial inference delay and improves inference speed, but requires some changes:
  * `4bit.pt` and `4bit.safetensors` mean new format, groupsize -1
  * `4bit-<groupsize>g.pt` and `4bit-<groupsize>g.safetensors` mean new format, groupsize `<groupsize>`
  * Legacy support was added, only to make the transition easier, will not be maintained in future. `4bit-old.pt` and `4bit-old.safetensors` mean old format.
* Multi-GPU support