### PR TITLE
Hook up use_default_badwordids in exllama

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -3918,7 +3918,8 @@ def generate(txt, minimum, maximum, found_entries=None, gen_mode=GenerationMode.
         return
 
     for i in range(koboldai_vars.numseqs):
-        koboldai_vars.lua_koboldbridge.generated[i+1][koboldai_vars.generated_tkns] = int(genout[i, -1].item())
+        if len(genout[i]) > 0:
+            koboldai_vars.lua_koboldbridge.generated[i+1][koboldai_vars.generated_tkns] = int(genout[i, -1].item())
         koboldai_vars.lua_koboldbridge.outputs[i+1] = utils.decodenewlines(tokenizer.decode(genout[i, -already_generated:]))
 
     execute_outmod()


### PR DESCRIPTION
Use the value of the `use_default_badwordids` setting to configure `bad_words_ids`. Also add square brackets to `bad_words_ids` if `use_default_badwordids` is True. Fix an issue with attempting to use the tokenizer too early, and fix an exception populating Lua bridge data when zero tokens are generated, which can now happen if `use_default_badwordids` is False and the first token generated is EOS. Eliminate the need for `trim_count` by moving the EOS early-out up.