### PR TITLE
Require Werkzeug 2

### DIFF
--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -51,3 +51,4 @@ dependencies:
     - --find-links=https://0cc4m.github.io/KoboldAI/gptq-whl-links.html
     - gptq_koboldai==0.0.6
     - einops
+    - Werkzeug==2.*

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -44,3 +44,4 @@ dependencies:
     - diffusers
     - git+https://github.com/0cc4m/hf_bleeding_edge/
     - einops
+    - Werkzeug==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ pytest-html==3.2.0
 pytest-metadata==2.0.4
 requests-mock==1.10.0
 safetensors
+Werkzeug==2.*


### PR DESCRIPTION
Werkzeug just had version 3.0.0 released: https://pypi.org/project/Werkzeug/#history

This causes the play.sh to not run properly.

Added a requirement in installation for Werkzeug version 2.*